### PR TITLE
Add view-custom

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'devise'
 gem 'jquery-rails'
 gem 'dotenv-rails'
 gem 'kaminari','~> 1.2.1'
+gem 'bootstrap4-kaminari-views'
 gem 'faker'
 gem 'gimei'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
+    bootstrap4-kaminari-views (1.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     builder (3.3.0)
     byebug (12.0.0)
     capybara (3.40.0)
@@ -291,6 +294,7 @@ PLATFORMS
 DEPENDENCIES
   active_storage_validations
   bootsnap (>= 1.4.4)
+  bootstrap4-kaminari-views
   byebug
   capybara (>= 3.26)
   devise

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -1,16 +1,12 @@
 class Admin::CommentsController < ApplicationController
   before_action :authenticate_admin!
   def index
-    @comments = Comment.all
+    @comments = Comment.all.order(created_at: :desc)
   end
 
   def active_switch
-    comment = Comment.find(params[:id])
-    if comment.update(is_active: !comment.is_active)
-      redirect_to request.referer
-    else
-      redirect_to admin_root_path
-    end
+    @comment = Comment.find(params[:id])
+    @comment.update(is_active: !@comment.is_active)
   end
 
   def destroy

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -2,7 +2,13 @@ class Admin::EventsController < ApplicationController
   before_action :authenticate_admin!
 
   def index
-    @events = Event.all.asc_datetime_order
+    @events = Event.all
+    @month = params[:month] ? Date.parse(params[:month]) : nil
+    if @month == nil
+      @events = @events.asc_datetime_order
+    else
+      @events = @events.where(date: @month.all_month).asc_datetime_order
+    end
   end
 
   def show
@@ -23,12 +29,8 @@ class Admin::EventsController < ApplicationController
   end
 
   def active_switch
-    event = Event.find(params[:id])
-    if event.update(is_active: !event.is_active)
-      redirect_to request.referer
-    else
-      redirect_to admin_root_path
-    end
+    @event = Event.find(params[:id])
+    @event.update_column(:is_active, !@event.is_active)
   end
 
   def destroy

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -9,12 +9,8 @@ class Admin::GroupsController < ApplicationController
   end
 
   def active_switch
-    group = Group.find(params[:id])
-    if group.update(is_active: !group.is_active)
-      redirect_to request.referer
-    else
-      redirect_to admin_root_path
-    end
+    @group = Group.find(params[:id])
+    @group.update(is_active: !@group.is_active)
   end
 
   def destroy

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -24,11 +24,16 @@ class Admin::UsersController < ApplicationController
   end
 
   def active_switch
-    user = User.find(params[:id])
-    if user.update(is_active: !user.is_active)
-      redirect_to request.referer
-    else
-      redirect_to admin_root_path
+    @user = User.find(params[:id])
+    if @user.update(is_active: !@user.is_active)
+      events = @user.events.get_since
+      events.each do |event|
+        event.update(is_active: false)
+      end
+      groups = @user.groups
+      groups.each do |group|
+        group.update(is_active: false)
+      end
     end
   end
 

--- a/app/controllers/concerns/search_functions.rb
+++ b/app/controllers/concerns/search_functions.rb
@@ -7,21 +7,27 @@ module SearchFunctions
       next if keyword == ""
       keyword = "%" + searches.sanitize_sql_like(keyword) + "%"
       case table
-      when User.name || Event.name || Group.name
+      when User.name
+        searches = searches.where(["name LIKE? OR introduction LIKE?", keyword, keyword])
+      when Event.name
         searches = searches.where(["name LIKE? OR introduction LIKE?", keyword, keyword])
       when Comment.name
         searches = searches.where("content LIKE?", keyword)
+      when Group.name
+        searches = searches.where(["name LIKE? OR introduction LIKE?", keyword, keyword])
       end
     end
 
     unless searches.empty?
       case table
-      when User.name || Group.name
-        searches.order(name: :asc)
+      when User.name
+        searches = searches.order(name: :asc)
       when Event.name
-        searches.asc_datetime_order
+        searches = searches.asc_datetime_order
       when Comment.name
         searches.order(create_at: :desc)
+      when Group.name
+        searches.order(name: :asc)
       end
     end
 

--- a/app/controllers/public/events_controller.rb
+++ b/app/controllers/public/events_controller.rb
@@ -9,7 +9,13 @@ class Public::EventsController < ApplicationController
   end
 
   def index
-    @events = Event.where(is_active: true).asc_datetime_order
+    @events = Event.where(is_active: true)
+    @month = params[:month] ? Date.parse(params[:month]) : nil
+    if @month == nil
+      @events = @events.asc_datetime_order
+    else
+      @events = @events.where(date: @month.all_month).asc_datetime_order
+    end
   end
 
   def show
@@ -30,6 +36,9 @@ class Public::EventsController < ApplicationController
 
   def edit
     @event = Event.find(params[:id])
+    unless @event.since_event?
+      redirect_to request.referer, alert: "過去のイベントは編集できません"
+    end
   end
 
   def update

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -32,7 +32,15 @@ class Public::UsersController < ApplicationController
 
   def withdraw
     user = current_user
-    user.update(is_active: :false)
+    user.update(is_active: false)
+    events = user.events.get_since
+    events.each do |event|
+      event.update(is_active: false)
+    end
+    groups = user.groups
+    groups.each do |group|
+      group.update(is_active: false)
+    end
     reset_session
     redirect_to new_user_registration_path, notice: "退会しました"
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -16,3 +16,4 @@ import "jquery";
 import "popper.js";
 import "bootstrap";
 import "../stylesheets/application";
+import "./script.js"

--- a/app/javascript/packs/script.js
+++ b/app/javascript/packs/script.js
@@ -1,0 +1,8 @@
+$(function(){
+  $('.over-secondary').mouseover(function(){
+    $(this).addClass('bg-secondary');
+  });
+  $('.over-secondary').mouseout(function(){
+    $(this).removeClass('bg-secondary');
+  });
+});

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -13,6 +13,12 @@
   background-color: #EC715F;
 }
 
+.orverflow-hidden {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .table td {
   vertical-align: middle;
 }
@@ -37,7 +43,7 @@ td p {
   position: relative;
 }
 
-.favorite {
+.left-top {
   position: absolute;
 }
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,6 +32,10 @@ class Event < ApplicationRecord
   scope :asc_datetime_order, -> { sort{ |a, b| a.get_datetime <=> b.get_datetime } }
   scope :desc_datetime_order, -> { sort{ |a, b| b.get_datetime <=> a.get_datetime } }
 
+  scope :get_ago, -> { where("date < ?", Time.zone.today) }
+  scope :get_since, -> { where("date >= ?", Time.zone.today) }
+
+
   def get_event_image
     unless event_image.attached?
       file_path = Rails.root.join('app/assets/images/events/no_event_image.jpg')
@@ -66,7 +70,7 @@ class Event < ApplicationRecord
 
   def check_date
     return if date.nil?
-    errors.add(:check_ago, "後以降の日時を入力してください") if date < Time.current.since(1.days)
+    errors.add(:check_since, "の日時を入力してください") if date < Time.current.since(1.days)
   end
 
   def check_time

--- a/app/views/admin/comments/_is_active.html.erb
+++ b/app/views/admin/comments/_is_active.html.erb
@@ -1,5 +1,5 @@
 <% if comment.is_active %>
-  <%= link_to "有効", active_switch_admin_comment_path(comment.id), class: "btn btn-sm m-1 btn-success" %>
+  <%= link_to "有効", active_switch_admin_comment_path(comment.id), class: "btn btn-sm m-1 btn-success", remote: true %>
 <% else %>
-  <%= link_to "無効", active_switch_admin_comment_path(comment.id), class: "btn btn-sm m-1 btn-danger" %>
+  <%= link_to "無効", active_switch_admin_comment_path(comment.id), class: "btn btn-sm m-1 btn-danger", remote: true %>
 <% end %>

--- a/app/views/admin/comments/_list.html.erb
+++ b/app/views/admin/comments/_list.html.erb
@@ -24,7 +24,9 @@
             </td>
             <td><%= comment.content %></td>
             <td>
-              <%= render "admin/comments/is_active", comment: comment %>
+              <span id="comment<%= comment.id %>_active_switch">
+                <%= render "admin/comments/is_active", comment: comment %>
+              </span>
               <%= link_to "削除", admin_comment_path(comment), method: :delete, class: "btn btn-sm m-1 btn-danger", data: { confirm: "本当に削除しますか？" } %>
             </td>
           </tr>

--- a/app/views/admin/comments/active_switch.js.erb
+++ b/app/views/admin/comments/active_switch.js.erb
@@ -1,0 +1,1 @@
+$("#comment<%= @comment.id %>_active_switch").html("<%= j(render "admin/comments/is_active", comment: @comment) %>");

--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex align-items-center">
-  <h2 class="heading col-lg-8 col-md-6">コメント（全<%= @comments.count %>件）</h2>
+  <h2 class="heading col-lg-8 col-md-6">コメント（<%= @comments.count %>）</h2>
   <% if admin_signed_in? %>
     <div class="ml-auto p-2 m-1"><%= link_to "全削除", destroy_all_admin_comments_path, method: :delete, class: "btn btn-sm btn-danger", data: { confirm: "無効コメントを全て削除します。\r\n本当に削除しますか？" } %></div>
   <% end %>

--- a/app/views/admin/events/_is_active.html.erb
+++ b/app/views/admin/events/_is_active.html.erb
@@ -1,5 +1,5 @@
 <% if event.is_active %>
-  <%= link_to "有効", active_switch_admin_event_path(event.id), class: "btn btn-sm m-1 btn-success" %>
+  <%= link_to "有効", active_switch_admin_event_path(event.id), class: "btn btn-sm m-1 btn-success", remote: true %>
 <% else %>
-  <%= link_to "無効", active_switch_admin_event_path(event.id), class: "btn btn-sm m-1 btn-danger" %>
+  <%= link_to "無効", active_switch_admin_event_path(event.id), class: "btn btn-sm m-1 btn-danger", remote: true %>
 <% end %>

--- a/app/views/admin/events/active_switch.js.erb
+++ b/app/views/admin/events/active_switch.js.erb
@@ -1,0 +1,1 @@
+$("#event<%= @event.id %>_active_switch").html("<%= j(render "admin/events/is_active", event: @event) %>");

--- a/app/views/admin/groups/_is_active.html.erb
+++ b/app/views/admin/groups/_is_active.html.erb
@@ -1,5 +1,5 @@
 <% if group.is_active %>
-  <%= link_to "有効", active_switch_admin_group_path(group.id), class: "btn btn-sm m-1 btn-success" %>
+  <%= link_to "有効", active_switch_admin_group_path(group.id), class: "btn btn-sm m-1 btn-success", remote: true %>
 <% else %>
-  <%= link_to "無効", active_switch_admin_group_path(group.id), class: "btn btn-sm m-1 btn-danger" %>
+  <%= link_to "無効", active_switch_admin_group_path(group.id), class: "btn btn-sm m-1 btn-danger", remote: true %>
 <% end %>

--- a/app/views/admin/groups/active_switch.js.erb
+++ b/app/views/admin/groups/active_switch.js.erb
@@ -1,0 +1,1 @@
+$("#group<%= @group.id %>_active_switch").html("<%= j(render "admin/groups/is_active", group: @group) %>");

--- a/app/views/admin/groups/show.html.erb
+++ b/app/views/admin/groups/show.html.erb
@@ -1,2 +1,1 @@
-<h1>Admin::Groups#show</h1>
-<p>Find me in app/views/admin/groups/show.html.erb</p>
+<%= render "layouts/groups/show", group: @group %>

--- a/app/views/admin/users/_is_active.html.erb
+++ b/app/views/admin/users/_is_active.html.erb
@@ -1,5 +1,5 @@
 <% if user.is_active %>
-  <%= link_to "有効", active_switch_admin_user_path(user.id), class: "btn btn-sm m-1 btn-success" %>
+  <%= link_to "有効", active_switch_admin_user_path(user.id), class: "btn btn-sm m-1 btn-success", remote: true %>
 <% else %>
-  <%= link_to "退会", active_switch_admin_user_path(user.id), class: "btn btn-sm m-1 btn-danger" %>
+  <%= link_to "退会", active_switch_admin_user_path(user.id), class: "btn btn-sm m-1 btn-danger", remote: true %>
 <% end %>

--- a/app/views/admin/users/active_switch.js.erb
+++ b/app/views/admin/users/active_switch.js.erb
@@ -1,0 +1,1 @@
+$("#user<%= @user.id %>_active_switch").html("<%= j(render "admin/users/is_active", user: @user) %>");

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/layouts/_admin_menu.html.erb
+++ b/app/views/layouts/_admin_menu.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 </li>
 <li class="col p-0">
-  <%=  link_to admin_events_path ,class: 'nav-link text-light text-center' do %>
+  <%=  link_to admin_events_path(month: Time.zone.today) ,class: 'nav-link text-light text-center' do %>
     <i class="fas fa-lg fa-dice"></i> イベント管理
   <% end %>
 </li>

--- a/app/views/layouts/_default_menu.html.erb
+++ b/app/views/layouts/_default_menu.html.erb
@@ -1,20 +1,20 @@
 <li class="col p-0">
-  <%= link_to root_path,class: 'nav-link text-light text-center' do %>
+  <%= link_to root_path,class: 'nav-link text-light text-center over-secondary' do %>
     <i class="fas fa-lg fa-home"></i> ほぉむ
   <% end %>
 </li>
 <li class="col p-0">
-  <%= link_to about_path,class: 'nav-link text-light text-center' do %>
+  <%= link_to about_path,class: 'nav-link text-light text-center over-secondary' do %>
     <i class="fas fa-lg fa-link"></i> あばうと
   <% end %>
 </li>
 <li class="col p-0">
-  <%= link_to new_user_registration_path,class: 'nav-link text-light text-center' do %>
+  <%= link_to new_user_registration_path,class: 'nav-link text-light text-center over-secondary' do %>
     <i class="fas fa-lg fa-user-plus"></i> 新規登録
   <% end %>
 </li>
 <li class="col p-0">
-  <%= link_to new_user_session_path ,class: 'nav-link text-light text-center' do %>
+  <%= link_to new_user_session_path ,class: 'nav-link text-light text-center over-secondary' do %>
     <i class="fas fa-lg fa-sign-in-alt"></i> ログイン
   <% end %>
 </li>

--- a/app/views/layouts/_flash_message.html.erb
+++ b/app/views/layouts/_flash_message.html.erb
@@ -1,5 +1,5 @@
 <% if flash[:notice] %>
-  <p class="alert alert-success"><%= notice %></p>
+  <p class="alert alert-success"><%= notice %><button type="button" class="close" data-dismiss="alert">&times;</button></p>
 <% elsif flash[:alert] %>
-  <p class="alert alert-danger"><%= alert %></p>
+  <p class="alert alert-danger"><%= alert %><button type="button" class="close" data-dismiss="alert">&times;</button></p>
 <% end %>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -9,7 +9,7 @@
   <% end %>
 </li>
 <li class="col p-0">
-  <%=  link_to events_path ,class: 'nav-link text-light text-center' do %>
+  <%=  link_to events_path(month: Time.zone.today) ,class: 'nav-link text-light text-center' do %>
     <i class="fas fa-lg fa-dice"></i> イベント
   <% end %>
 </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,10 +14,10 @@
   <body class="d-flex flex-column vh-100">
     <%= render 'layouts/header' %>
     <main class="mb-auto">
-    <div class="container py-3 shadow-lg rounded">
-      <%= render 'layouts/flash_message' %>
-      <%= yield %>
-    <div>
+      <div class="container py-3 rounded">
+        <%= render 'layouts/flash_message' %>
+        <%= yield %>
+      <div>
     </main>
     <%= render 'layouts/footer' %>
   </body>

--- a/app/views/layouts/events/_index.html.erb
+++ b/app/views/layouts/events/_index.html.erb
@@ -1,5 +1,50 @@
 <div class="d-flex align-items-center">
-  <h2 class="heading col-lg-8 col-md-6">イベント（全<%= events.count %>件）</h2>
+  <div class="heading col-lg-8 col-md-6">
+    <span class="h2">イベント（<%= events.count %>）</span>
+    <span class="h4">
+      <% unless @month.nil? %>
+        <% if admin_signed_in? %>
+          <%= link_to admin_events_path(month: @month.prev_month) do %>
+            <i class="fas fa-sm fa-circle-chevron-left"></i>
+          <% end %>
+          <%= @month.strftime('%Y年%m月') %>
+          <%= link_to admin_events_path(month: @month.next_month) do %>
+            <i class="fas fa-sm fa-circle-chevron-right"></i>
+          <% end %>
+        <% elsif user_signed_in? %>
+          <%= link_to events_path(month: @month.prev_month) do %>
+            <i class="fas fa-sm fa-circle-chevron-left"></i>
+          <% end %>
+          <%= @month.strftime('%Y年%m月') %>
+          <%= link_to events_path(month: @month.next_month) do %>
+            <i class="fas fa-sm fa-circle-chevron-right"></i>
+          <% end %>
+        <% end %>
+      <% end %>
+    </span>
+    <% unless @month == Time.zone.today %>
+      <% if admin_signed_in? %>
+        <%= link_to admin_events_path(month: Time.current) do %>
+          <span> [当月] </span>
+        <% end %>
+      <% elsif user_signed_in? %>
+        <%= link_to events_path(month: Time.current) do %>
+          <span> [当月] </span>
+        <% end %>
+      <% end %>
+    <% end %>
+    <% unless @month.nil? %>
+      <% if admin_signed_in? %>
+        <%= link_to admin_events_path(month: nil) do %>
+          <span> [全表示] </span>
+        <% end %>
+      <% elsif user_signed_in? %>
+        <%= link_to events_path(month: nil) do %>
+          <span> [全表示] </span>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
   <% if admin_signed_in? %>
     <div class="ml-auto p-2 m-1"><%= link_to "全削除", destroy_all_admin_events_path, method: :delete, class: "btn btn-sm btn-danger", data: { confirm: "無効イベントを全て削除します。\r\n本当に削除しますか？" } %></div>
   <% elsif user_signed_in? %>

--- a/app/views/layouts/events/_show.html.erb
+++ b/app/views/layouts/events/_show.html.erb
@@ -2,13 +2,17 @@
   <h2 class="heading col-lg-8 col-md-6">イベント詳細</h2>
   <% if admin_signed_in? %>
     <div class="ml-auto p-2">
-      <%= render "admin/events/is_active", event: event %>
+      <span id="event<%= event.id %>_active_switch" %>
+        <%= render "admin/events/is_active", event: event %>
+      </span>
       <%= link_to "編集", edit_admin_event_path(event.id), class: "btn btn-sm btn-info m-1" %>
       <%= link_to "削除", admin_event_path, method: :delete, class: "btn btn-sm btn-danger m-1", data: { confirm: '本当に削除しますか？' } %>
     </div>
   <% elsif current_id?(event.user_id) %>
     <div class="ml-auto p-2">
-      <%= link_to "編集", edit_event_path(event.id), class: "btn btn-sm btn-info m-1" %>
+      <% if event.since_event? %>
+        <%= link_to "編集", edit_event_path(event.id), class: "btn btn-sm btn-info m-1" %>
+      <% end %>
       <%= link_to "削除", event_path, method: :delete, class: "btn btn-sm btn-danger m-1", data: { confirm: '本当に削除しますか？' } %>
     </div>
   <% end %>
@@ -101,11 +105,23 @@
       <tbody>
         <% comments.each do |comment| %>
           <tr>
-            <td class="col-1"><%= render "layouts/events/participant_icon", user: comment.user %></td>
+            <td class="col-1">
+              <% if admin_signed_in? %>
+                <%= link_to admin_user_path(comment.user.id) do %>
+                  <%= render "layouts/events/participant_icon", user: comment.user %>
+                <% end %>
+              <% elsif user_signed_in? %>
+                <%= link_to user_path(comment.user.id) do %>
+                  <%= render "layouts/events/participant_icon", user: comment.user %>
+                <% end %>
+              <% end %>
+            </td>
             <td class="col-9"><%= comment.content %></td>
             <td class="col-2">
               <% if admin_signed_in? %>
-                <%= render "admin/comments/is_active", comment: comment %>
+                <span id="comment<%= comment.id %>_active_switch">
+                  <%= render "admin/comments/is_active", comment: comment %>
+                </span>
                 <%= link_to "削除", admin_comment_path(comment), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-sm m-1 btn-danger" %>
               <% elsif user_signed_in? && current_id?(comment.user_id) %>
                 <%= link_to "削除", event_comment_path(event, comment), method: :delete, data: { confirm: '本当に消しますか？' }, class: "btn btn-sm btn-danger" %>

--- a/app/views/layouts/events/_thumbnail.html.erb
+++ b/app/views/layouts/events/_thumbnail.html.erb
@@ -1,4 +1,9 @@
 <div class="card shadow-lg rounde">
+  <% if admin_signed_in? %>
+    <object id="event<%= event.id %>_active_switch" class="text-center left-top">
+      <%= render "admin/events/is_active", event: event %>
+    </object>
+  <% end %>
   <div class="bg-light">
     <%= image_tag event.get_event_image, size: "160x90", class: "card-img-top cover-image" %>
   </div>
@@ -25,7 +30,4 @@
       </tr>
     </tbody>
   </table>
-  <% if admin_signed_in? %>
-    <%= render "admin/events/is_active", event: event %>
-  <% end %>
 </div>

--- a/app/views/layouts/groups/_index.html.erb
+++ b/app/views/layouts/groups/_index.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex align-items-center">
-  <h2 class="heading col-lg-8 col-md-6">グループ（全<%= groups.count %>個）</h2>
+  <h2 class="heading col-lg-8 col-md-6">グループ（<%= groups.count %>）</h2>
   <% if admin_signed_in? %>
     <div class="ml-auto p-2 m-1"><%= link_to "全削除", destroy_all_admin_groups_path, method: :delete, class: "btn btn-sm btn-danger", data: { confirm: "退会済ユーザーを全て削除します。\r\n本当に削除しますか？" } %></div>
   <% elsif user_signed_in? %>
@@ -9,4 +9,6 @@
   <% end %>
 </div>
 
-<%= render "layouts/groups/list", groups: groups %>
+<div class="col">
+  <%= render "layouts/groups/list", groups: groups %>
+</div>

--- a/app/views/layouts/groups/_list.html.erb
+++ b/app/views/layouts/groups/_list.html.erb
@@ -12,7 +12,13 @@
       <tbody>
         <% groups.each do |group| %>
           <tr>
-            <td><%= link_to group.name, group_path(group.id) %></td>
+            <td>
+              <% if admin_signed_in? %>
+                <%= link_to group.name, admin_group_path(group.id) %>
+              <% elsif user_signed_in? %>
+                <%= link_to group.name, group_path(group.id) %>
+              <% end %>
+            </td>
             <td>
               <% if admin_signed_in? %>
                 <%= link_to admin_user_path(group.user.id) do %>
@@ -39,7 +45,9 @@
             </td>
             <td>
               <% if admin_signed_in? %>
-                <%= render "admin/groups/is_active", group: group %>
+                <span id="group<%= group.id %>_active_switch">
+                  <%= render "admin/groups/is_active", group: group %>
+                </span>
                 <%= link_to "削除", admin_group_path(group.id), method: :delete, class: "btn btn-sm btn-danger m-1" , data: { confirm: "本当に削除しますか？" } %>
               <% elsif user_signed_in? %>
                 <% if current_id?(group.user_id) %>

--- a/app/views/layouts/groups/_show.html.erb
+++ b/app/views/layouts/groups/_show.html.erb
@@ -4,9 +4,11 @@
   </h2>
   <div class="ml-auto p-2 m-1">
     <% if admin_signed_in? %>
-      <%= render "admin/groups/is_active", user: user %>
-      <%= link_to "編集", edit_admin_group_path(user.id), class: "btn btn-sm btn-info m-1" %>
-      <%= link_to "削除", admin_group_path(user.id), method: :delete, class: "btn btn-sm btn-danger m-1", data: { confirm: "本当に削除しますか？" } %>
+      <span id="group<%= group.id %>_active_switch">
+        <%= render "admin/groups/is_active", group: group %>
+      </span>
+      <%= link_to "編集", edit_admin_group_path(group.id), class: "btn btn-sm btn-info m-1" %>
+      <%= link_to "削除", admin_group_path(group.id), method: :delete, class: "btn btn-sm btn-danger m-1", data: { confirm: "本当に削除しますか？" } %>
     <% elsif user_signed_in? && current_id?(group.user_id) %>
       <%= link_to "編集", edit_group_path, class:"btn btn-sm btn-info m-1" %>
       <%= link_to "削除", group_path(group.id), method: :delete, class: "btn btn-sm btn-danger m-1", data: { confirm: "本当に削除しますか？" } %>
@@ -16,12 +18,13 @@
   </div>
 </div>
 
-<div class="d-flex justify-content-center">
+<div class="my-5 col"><%= group.introduction %></div>
+
+<div class="col d-flex justify-content-center">
   <table class="table px-3">
-    <tbody>
+    <thead>
       <tr>
-        <td class="col-md-2 col-4" rowspan="<%= group.members.count + 1 %>">メンバー</td>
-        <td class="col-md-10 col-8">
+        <th>
           <% if admin_signed_in? %>
             <%= link_to admin_user_path(group.user.id) do %>
               <%= render "layouts/groups/leader", user: group.user %>（リーダー）
@@ -31,8 +34,10 @@
               <%= render "layouts/groups/leader", user: group.user %>（リーダー）
             <% end %>
           <% end %>
-        </td>
+        </th>
       </tr>
+    </thead>
+    <tbody>
       <% if group.users.present? %>
         <% group.users.each do |user| %>
           <tr>
@@ -49,6 +54,8 @@
             </td>
           </tr>
         <% end %>
+      <% else %>
+        メンバーはいません
       <% end %>
     </tbody>
   </table>

--- a/app/views/layouts/searches/_search.html.erb
+++ b/app/views/layouts/searches/_search.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex align-items-center">
-  <h2 class="heading col-lg-8 col-md-6">検索結果（全 <%= searches.count %> 件）</h2>
+  <h2 class="heading col-lg-8 col-md-6">検索結果（<%= searches.count %>）</h2>
 </div>
 
 <% if table == User.name %>

--- a/app/views/layouts/users/_event_list.html.erb
+++ b/app/views/layouts/users/_event_list.html.erb
@@ -25,12 +25,16 @@
           <td><%= event.participants.count %> / <%= event.max_people %> 人</td>
           <td class="text-center">
             <% if admin_signed_in? %>
-              <%= render "admin/events/is_active", event: event %>
+              <span id="event<%= event.id %>_active_switch">
+                <%= render "admin/events/is_active", event: event %>
+              </span>
               <%= link_to "編集", edit_admin_event_path(event.id), class: "btn btn-sm btn-info m-1" %>
               <%= link_to "削除", admin_event_path, method: :delete, class: "btn btn-sm btn-danger m-1", data: { confirm: '本当に削除しますか？' } %>
             <% elsif user_signed_in? %>
               <% if current_id?(event.user_id) %>
-                <%= link_to "編集", edit_event_path(event.id), class: "btn btn-sm btn-info m-1" %>
+                <% if event.since_event? %>
+                  <%= link_to "編集", edit_event_path(event.id), class: "btn btn-sm btn-info m-1" %>
+                <% end %>
                 <%= link_to "削除", event_path, method: :delete, class: "btn btn-sm btn-danger m-1", data: { confirm: '本当に削除しますか？' } %>
               <% else %>
                 <%= render "layouts/events/participant", event: event %>

--- a/app/views/layouts/users/_index.html.erb
+++ b/app/views/layouts/users/_index.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex align-items-center">
-  <h2 class="heading col-lg-8 col-md-6">ユーザー（全<%= users.count %>人）</h2>
+  <h2 class="heading col-lg-8 col-md-6">ユーザー（<%= users.count %>）</h2>
   <% if admin_signed_in? %>
     <div class="ml-auto p-2 m-1"><%= link_to "全削除", destroy_all_admin_users_path, method: :delete, class: "btn btn-sm btn-danger", data: { confirm: "退会済ユーザーを全て削除します。\r\n本当に削除しますか？" } %></div>
   <% elsif user_signed_in? %>

--- a/app/views/layouts/users/_show.html.erb
+++ b/app/views/layouts/users/_show.html.erb
@@ -8,7 +8,9 @@
   </h2>
   <% if admin_signed_in? %>
     <div class="ml-auto p-2">
-      <%= render "admin/users/is_active", user: user %>
+      <span id="user<%= user.id %>_active_switch">
+        <%= render "admin/users/is_active", user: user %>
+      </span>
       <%= link_to "編集", edit_admin_user_path(user.id), class: "btn btn-sm btn-info m-1" %>
       <%= link_to "削除", admin_user_path(user.id), method: :delete, class: "btn btn-sm btn-danger m-1", data: { confirm: "本当に削除しますか？" } %>
     </div>
@@ -30,9 +32,19 @@
         <div class="ml-auto p-2"><%= link_to "新規作成", new_event_path, class: "btn btn-sm btn-primary m-1" %></div>
       <% end %>
     </div>
-    <%= render "layouts/users/event_list", events: events, user: current_user %>
+    <%= render "layouts/users/event_list", events: events.get_since %>
 
     <h3 class="heading col-8 p-0 mt-5">参加イベント</h3>
-    <%= render "layouts/users/event_list", events: participated_events, user: current_user %>
+    <%= render "layouts/users/event_list", events: participated_events.get_since %>
+
+    <details>
+      <summary>過去イベント</summary>
+      <div class="pl-2">
+        <h6 class="col-8 heading p-0">主催イベント</h4>
+        <%= render "layouts/users/event_list", events: events.get_ago %>
+        <h6 class="col-8 heading p-0">参加イベント</h4>
+        <%= render "layouts/users/event_list", events: participated_events.get_ago %>
+      </div>
+    </details>
   </div>
 </div>

--- a/app/views/layouts/users/_thumbnail.html.erb
+++ b/app/views/layouts/users/_thumbnail.html.erb
@@ -1,9 +1,11 @@
 <div class="card shadow-lg rounde">
+  <% if admin_signed_in? %>
+    <object id="user<%= user.id %>_active_switch" class="text-center left-top">
+      <%= render "admin/users/is_active", user: user %>
+    </object>
+  <% end %>
   <div class="bg-light p-1">
     <%= image_tag user.get_user_image(50, 50),size: "50x50", class: "d-block bg-white mx-auto rounded-circle border border-dark cover-image", alt: "ユーザーアイコン" %>
   </div>
-  <div class="p-2 text-center small"><%= user.name %></div>
-  <% if admin_signed_in? %>
-    <%= render "admin/users/is_active", user: user %>
-  <% end %>
+  <div class="p-2 text-center small orverflow-hidden"><%= user.name %></div>
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -38,7 +38,7 @@ ja:
         min_people: 最低人数
         max_people: 最大人数
         check_people: 人数の大小関係
-        check_ago: 24時間
+        check_since: 24時間後以降
         check_time: 終了時間
     models:
       user: ユーザー


### PR DESCRIPTION
 # Add view-custom
 - グループ詳細ページの調整
 - イベントを月ごとに表示
 - ユーザーページのイベントデータのうち、過去のものを別に表示
 - 退会ユーザーのイベントを非アクティブ化
 - active_switchの非同期通信化